### PR TITLE
Fix `requireSync` within node

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build:esm:rename:map": "find ./lib -type f -name '*.js.map' | sed -E 's/^(.+)\\.js\\.map$/\\1/' | xargs -I % mv %.js.map %.mjs.map",
     "clean": "rm -rf cjs esm lib build temp .cache",
     "prepublishOnly": "run-s test build",
+    "prepare": "run-s build",
     "start": "npm run clean && npm run build:esm -- --watch",
     "test": "jest",
     "compare:babel": "babel -o ./compare/output_babel.js ./compare/source.ts",

--- a/src/properties/createRequireSync.ts
+++ b/src/properties/createRequireSync.ts
@@ -9,7 +9,7 @@ const REQUIRE_SYNC_BODY = ts.factory.createReturnStatement(
   ts.factory.createConditionalExpression(
     ts.factory.createBinaryExpression(
       ts.factory.createTypeOfExpression(
-        ts.factory.createStringLiteral('__webpack_require__'),
+        ts.factory.createIdentifier('__webpack_require__'),
       ),
       ts.SyntaxKind.ExclamationEqualsEqualsToken,
       ts.factory.createStringLiteral('undefined'),


### PR DESCRIPTION
Comparing against the output of the babel plugin, the comparison in
`requireSync` should be an identifier, not a string (otherwise, the
conditional will always be `true`).

Added a `prepare` npm script as well so that the built version can be used with git / non-published imports (needed for my own use, fine to remove it if needed).